### PR TITLE
extract_utils: Fix locale issue with sort

### DIFF
--- a/build/tools/extract_utils.sh
+++ b/build/tools/extract_utils.sh
@@ -595,7 +595,7 @@ function parse_file_list() {
             PRODUCT_COPY_FILES_HASHES+=("$HASH")
         fi
 
-    done < <(egrep -v '(^#|^[[:space:]]*$)' "$1" | sort | uniq)
+    done < <(egrep -v '(^#|^[[:space:]]*$)' "$1" | LC_ALL=C sort | uniq)
 }
 
 #


### PR DESCRIPTION
* On some machines, LC_ALL=C is set, causing the sort
  order of makefiles to be different than those without
  this locale change that is set
* Set LC_ALL=C on all machines for consistent ordering
* From 'man sort':
  The locale specified by the environment affects sort order.
  Set LC_ALL=C to get the traditional sort order that uses native byte values.
* Thanks to haggertk and rashed for verifying this for me

Change-Id: I5bbb94b0dfe599a67036de4312e8af913e9b8d30
Signed-off-by: Paul Keith <javelinanddart@aidenswann.com>